### PR TITLE
Feat: TabNavBar 아이콘 선택시 이동 기능 추가

### DIFF
--- a/src/components/common/TabNavBar/TabNav.jsx
+++ b/src/components/common/TabNavBar/TabNav.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import {
@@ -11,35 +12,67 @@ import {
   USER_FILL,
 } from '../../../styles/CommonIcons';
 
-export default function TabNav() {
+const TabNav = () => {
+  const [currentTabId, setCurrentTabId] = useState(0);
+  const navigate = useNavigate();
+
+  const tabList = [
+    { id: 0, title: '홈', icon: HOME, fillIcon: HOME_FILL },
+    {
+      id: 1,
+      title: '채팅',
+      icon: MESSAGE_CIRCLE_LG,
+      fillIcon: MESSAGE_CIRCLE_FILL,
+    },
+    { id: 2, title: '게시물 작성', icon: EDIT, fillIcon: EDIT },
+    { id: 3, title: '프로필', icon: USER_ICON, fillIcon: USER_FILL },
+  ];
+
+  useEffect(() => {
+    const storedTabId = localStorage.getItem('selectedTabId');
+    if (storedTabId) {
+      setCurrentTabId(parseInt(storedTabId));
+    }
+  }, []);
+
+  const pageMove = (id) => {
+    setCurrentTabId(id);
+    localStorage.setItem('selectedTabId', id); // 선택된 탭의 ID를 로컬 스토리지에 저장
+
+    switch (id) {
+      case 0:
+        navigate('/');
+        break;
+      case 1:
+        navigate('/chatList');
+        break;
+      case 2:
+        navigate('/post/upload');
+        break;
+      case 3:
+        navigate('/profile');
+        break;
+      default:
+    }
+  };
+
   return (
-    <>
-      <TabNavBar>
-        <TabNavUl>
-          <TabNavLi>
-            <img src={HOME_FILL} alt='홈 선택' />
-            <TabNavSpan>홈</TabNavSpan>
+    <TabNavBar>
+      <TabNavUl>
+        {tabList.map(({ id, title, icon, fillIcon }) => (
+          <TabNavLi key={id} onClick={() => pageMove(id)}>
+            <img src={id === currentTabId ? fillIcon : icon} alt='' />
+            <TabNavTitle id={id} currentTabId={currentTabId}>
+              {title}
+            </TabNavTitle>
           </TabNavLi>
-
-          <TabNavLi>
-            <img src={MESSAGE_CIRCLE_LG} alt='채팅' />
-            <TabNavSpan>채팅</TabNavSpan>
-          </TabNavLi>
-
-          <TabNavLi>
-            <img src={EDIT} alt='게시물 작성' />
-            <TabNavSpan>게시물 작성</TabNavSpan>
-          </TabNavLi>
-
-          <TabNavLi>
-            <img src={USER_ICON} alt='프로필' />
-            <TabNavSpan>프로필</TabNavSpan>
-          </TabNavLi>
-        </TabNavUl>
-      </TabNavBar>
-    </>
+        ))}
+      </TabNavUl>
+    </TabNavBar>
   );
-}
+};
+
+export default TabNav;
 
 const TabNavBar = styled.footer`
   width: 100%;
@@ -49,7 +82,7 @@ const TabNavBar = styled.footer`
   bottom: 0;
   z-index: 100;
   background-color: #fff;
-  border-top: 1px solid #dbdbdb;
+  border-top: 1px solid var(--gray-200);
 `;
 
 const TabNavUl = styled.ul`
@@ -73,9 +106,13 @@ const TabNavLi = styled.li`
   }
 `;
 
-const TabNavSpan = styled.span`
+const TabNavTitle = styled.span`
   display: block;
-  font-size: 10px;
+  font-size: 1rem;
+  color: ${(props) =>
+    props.id === props.currentTabId
+      ? 'var(--primary-color)'
+      : 'var(--gray-400)'};
 `;
 
 // 테스트용 주석


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

### 반영 브랜치
feat-TabNav -> main

### 변경 사항
* 하단 탭 메뉴 클릭 시 페이지 이동 및 fillicon으로 변경
* 새로고침 눌러도 마지막에 선택된 아이콘 유지
~~브라우저 뒤로가기 버튼 눌렀을 때 아이콘이 따라가지 않는 부분은 수정해야 할 것 같습니다~~ 


### 실행 결과 스크린샷 (없을 경우 생략)
![image](https://github.com/FRONTENDSCHOOL5/final-08-Off-field-baseball/assets/126536476/00f873cb-cf23-40ac-8763-4c913183663e)
