### PR TITLE
feat: 모달 기능

### DIFF
--- a/src/components/common/Modal/MoreModal.jsx
+++ b/src/components/common/Modal/MoreModal.jsx
@@ -1,19 +1,51 @@
+import { useEffect } from 'react';
 import Overlay from './Overlay';
 import styled from 'styled-components';
+import { useRef } from 'react';
 
-const MoreModal = ({ menuList }) => {
+const MoreModal = ({ menuList, isModalOpen, setIsModalOpen }) => {
+  // tab을 누르면, 모달 안에서만 포커스 되게
+  const handleKeyDown = (e) => {
+    if (!e.shiftKey && e.key === 'Tab') {
+      if (!e.target.parentNode.nextElementSibling) {
+        e.preventDefault();
+        e.target.parentNode.parentNode.firstElementChild.firstElementChild.focus();
+      }
+    }
+  };
+
+  // 모달 외 클릭 시 모달 close
+  const handleClick = (e) => {
+    if (!e.target.closest('dialog')) {
+      setIsModalOpen(false);
+    }
+  };
+
+  // 모달이 open되면 모달 첫번째 요소에 focus
+  const firstEl = useRef();
+  useEffect(() => {
+    if (isModalOpen) {
+      firstEl.current.focus();
+    }
+  }, []);
+
   return (
-    <Overlay>
-      <StyledDialog
-        open
-        role='dialog'
-        aria-labelledby='title-dialog'
-        aria-describedby='desc-txt'
-      >
-        <ul>
-          {menuList.map((menu) => {
+    <Overlay onClick={handleClick}>
+      <StyledDialog open role='dialog'>
+        <ul onKeyDown={handleKeyDown}>
+          {menuList.map((menu, i) => {
+            if (i === 0) {
+              return (
+                <li key={i}>
+                  <button ref={firstEl} type='button'>
+                    {menu}
+                  </button>
+                </li>
+              );
+            }
+
             return (
-              <li>
+              <li key={i}>
                 <button type='button'>{menu}</button>
               </li>
             );
@@ -27,7 +59,7 @@ const MoreModal = ({ menuList }) => {
 export default MoreModal;
 
 MoreModal.defaultProps = {
-  menuList: ['신고'],
+  menuList: ['설정 및 개인정보', '로그아웃'],
 };
 
 const StyledDialog = styled.dialog`
@@ -53,5 +85,8 @@ const StyledDialog = styled.dialog`
     font-size: 1.4rem;
     line-height: 1.8rem;
     text-align: left;
+  }
+  button:focus {
+    outline: 1px solid var(--primary-color);
   }
 `;

--- a/src/components/common/Modal/MoreModal.jsx
+++ b/src/components/common/Modal/MoreModal.jsx
@@ -1,0 +1,57 @@
+import Overlay from './Overlay';
+import styled from 'styled-components';
+
+const MoreModal = ({ menuList }) => {
+  return (
+    <Overlay>
+      <StyledDialog
+        open
+        role='dialog'
+        aria-labelledby='title-dialog'
+        aria-describedby='desc-txt'
+      >
+        <ul>
+          {menuList.map((menu) => {
+            return (
+              <li>
+                <button type='button'>{menu}</button>
+              </li>
+            );
+          })}
+        </ul>
+      </StyledDialog>
+    </Overlay>
+  );
+};
+
+export default MoreModal;
+
+MoreModal.defaultProps = {
+  menuList: ['신고'],
+};
+
+const StyledDialog = styled.dialog`
+  position: fixed;
+  bottom: 0;
+  width: min(100%, 430px);
+  border: none;
+  padding: 0;
+  border-radius: 10px 10px 0 0;
+
+  ul::before {
+    display: block;
+    content: '';
+    margin: 16px auto;
+    width: 50px;
+    height: 4px;
+    background-color: var(--gray-200);
+    border-radius: 2px;
+  }
+  li > button {
+    padding: 14px 26px;
+    width: 100%;
+    font-size: 1.4rem;
+    line-height: 1.8rem;
+    text-align: left;
+  }
+`;

--- a/src/components/common/Modal/MoreModal.jsx
+++ b/src/components/common/Modal/MoreModal.jsx
@@ -3,7 +3,12 @@ import Overlay from './Overlay';
 import styled from 'styled-components';
 import { useRef } from 'react';
 
-const MoreModal = ({ menuList, isModalOpen, setIsModalOpen }) => {
+const MoreModal = ({
+  menuList,
+  clickEventListnerList,
+  isModalOpen,
+  setIsModalOpen,
+}) => {
   // tab을 누르면, 모달 안에서만 포커스 되게
   const handleKeyDown = (e) => {
     if (!e.shiftKey && e.key === 'Tab') {
@@ -29,6 +34,15 @@ const MoreModal = ({ menuList, isModalOpen, setIsModalOpen }) => {
     }
   }, []);
 
+  const handleError = () => {
+    alert('기능이 없습니다');
+    console.log(new Error('이벤트 리스너를 전달해주세요'));
+  };
+
+  MoreModal.defaultProps = {
+    menuList: ['정의되지 않음'],
+  };
+
   return (
     <Overlay onClick={handleClick}>
       <StyledDialog open role='dialog'>
@@ -37,16 +51,24 @@ const MoreModal = ({ menuList, isModalOpen, setIsModalOpen }) => {
             if (i === 0) {
               return (
                 <li key={i}>
-                  <button ref={firstEl} type='button'>
+                  <button
+                    ref={firstEl}
+                    type='button'
+                    onClick={clickEventListnerList[i] || handleError}
+                  >
                     {menu}
                   </button>
                 </li>
               );
             }
-
             return (
               <li key={i}>
-                <button type='button'>{menu}</button>
+                <button
+                  type='button'
+                  onClick={clickEventListnerList[i] || handleError}
+                >
+                  {menu}
+                </button>
               </li>
             );
           })}
@@ -57,10 +79,6 @@ const MoreModal = ({ menuList, isModalOpen, setIsModalOpen }) => {
 };
 
 export default MoreModal;
-
-MoreModal.defaultProps = {
-  menuList: ['설정 및 개인정보', '로그아웃'],
-};
 
 const StyledDialog = styled.dialog`
   position: fixed;

--- a/src/components/common/Modal/Overlay.jsx
+++ b/src/components/common/Modal/Overlay.jsx
@@ -2,11 +2,20 @@ import styled from 'styled-components';
 
 const Overlay = styled.div`
   position: fixed;
-  background: #00000040; // 임시 색
   top: 0;
   bottom: 0;
-  width: inherit;
+  left: 0;
+  right: 0;
   z-index: 1000;
+
+  &:before {
+    content: '';
+    display: block;
+    background: #00000030; // 임시 색
+    width: min(100%, 430px);
+    height: 100%;
+    margin: auto;
+  }
 `;
 
 export default Overlay;

--- a/src/components/common/Modal/Overlay.jsx
+++ b/src/components/common/Modal/Overlay.jsx
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+const Overlay = styled.div`
+  position: fixed;
+  background: #00000040; // 임시 색
+  top: 0;
+  bottom: 0;
+  width: inherit;
+  z-index: 1000;
+`;
+
+export default Overlay;

--- a/src/components/common/Modal/SettingModal.jsx
+++ b/src/components/common/Modal/SettingModal.jsx
@@ -1,0 +1,17 @@
+import MoreModal from './MoreModal';
+
+const SettingModal = ({ isModalOpen, setIsModalOpen }) => {
+  const logout = () => {
+    alert('삭제하기 모달');
+  };
+
+  return (
+    <MoreModal
+      menuList={['설정 및 개인정보', '로그아웃']}
+      clickEventListnerList={[logout]}
+      isModalOpen={isModalOpen}
+      setIsModalOpen={setIsModalOpen}
+    ></MoreModal>
+  );
+};
+export default SettingModal;

--- a/src/components/common/TopNavBar/TopBasicNav.jsx
+++ b/src/components/common/TopNavBar/TopBasicNav.jsx
@@ -2,8 +2,11 @@ import React from 'react';
 import { TopNavBar, LeftArrow, MoreBtn } from './Styled';
 import { ARROW_LEFT, MORE_VERTICAL } from '../../../styles/CommonIcons';
 import styled from 'styled-components';
+import MoreModal from '../Modal/SettingModal';
+import { useState } from 'react';
 
-export default function TopBasicNav({ loc, setIsModalOpen }) {
+export default function TopBasicNav({ loc }) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
   return (
     <>
       <TopNavBar>
@@ -16,6 +19,13 @@ export default function TopBasicNav({ loc, setIsModalOpen }) {
           <MoreBtn onClick={() => setIsModalOpen(true)}>
             <img src={MORE_VERTICAL} alt='more' />
           </MoreBtn>
+        )}
+
+        {isModalOpen && (
+          <MoreModal
+            isModalOpen={isModalOpen}
+            setIsModalOpen={setIsModalOpen}
+          />
         )}
       </TopNavBar>
     </>

--- a/src/components/common/TopNavBar/TopBasicNav.jsx
+++ b/src/components/common/TopNavBar/TopBasicNav.jsx
@@ -3,7 +3,7 @@ import { TopNavBar, LeftArrow, MoreBtn } from './Styled';
 import { ARROW_LEFT, MORE_VERTICAL } from '../../../styles/CommonIcons';
 import styled from 'styled-components';
 
-export default function TopBasicNav({ loc }) {
+export default function TopBasicNav({ loc, setIsModalOpen }) {
   return (
     <>
       <TopNavBar>
@@ -13,7 +13,7 @@ export default function TopBasicNav({ loc }) {
         {loc === 'follow' ? (
           <TopNavH2>Followers</TopNavH2>
         ) : (
-          <MoreBtn>
+          <MoreBtn onClick={() => setIsModalOpen(true)}>
             <img src={MORE_VERTICAL} alt='more' />
           </MoreBtn>
         )}

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -17,16 +17,16 @@ export default function Login({ team }) {
       <h1>로그인</h1>
       <Form team={team}>
         <label htmlFor='email-inp'>이메일</label>
-        <input id='email-inp' type='text' />
+        <input id='email-inp' type='email' />
         <label htmlFor='password-inp'>비밀번호</label>
-        <input id='password-inp' type='text' />
+        <input id='password-inp' type='password' />
         <Link to='/'>
           <StyledButton
             type='submit'
             bgColor={
               isValid ? 'var(--primary-color)' : 'var(--secondary-color)'
             }
-            padding='13px 0'
+            lBtn
             disabled={isValid ? '' : 'disabled'}
           >
             로그인

--- a/src/pages/Upload/Post.jsx
+++ b/src/pages/Upload/Post.jsx
@@ -5,9 +5,10 @@ import Comment from '../../components/common/Comment/Comment';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import Post from '../../components/common/Post/Post';
+import MoreModal from '../../components/common/Modal/MoreModal';
 
 export default function Upload() {
-  const [isImg, setIsImg] = useState(true); // 레이아웃을 위해 임시로 true
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   return (
     <>
@@ -15,7 +16,7 @@ export default function Upload() {
       <h1 className='a11y-hidden'>구장 밖 야구</h1>
       <h2 className='a11y-hidden'>{'애월읍 위니브 감귤농장'} 포스트 페이지</h2>
 
-      <TopBasicNav />
+      <TopBasicNav setIsModalOpen={setIsModalOpen} />
       <StyledSection>
         <Post></Post>
       </StyledSection>
@@ -45,10 +46,13 @@ export default function Upload() {
         </article>
       </CommentListSection>
       <Comment txt='게시' placeholder='댓글 입력하기'></Comment>
+
+      {isModalOpen && (
+        <MoreModal isModalOpen={isModalOpen} setIsModalOpen={setIsModalOpen} />
+      )}
     </>
   );
 }
-
 const CommentListSection = styled.section`
   border-top: 1px solid var(--gray-200);
   padding: 20px 16px 82px; //bottom : form 높이 + 20px

--- a/src/pages/Upload/Post.jsx
+++ b/src/pages/Upload/Post.jsx
@@ -2,21 +2,17 @@ import { BASIC_PROFILE_SM } from '../../styles/CommonIcons';
 import styled from 'styled-components';
 import TopBasicNav from '../../components/common/TopNavBar/TopBasicNav';
 import Comment from '../../components/common/Comment/Comment';
-import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import Post from '../../components/common/Post/Post';
-import MoreModal from '../../components/common/Modal/MoreModal';
 
 export default function Upload() {
-  const [isModalOpen, setIsModalOpen] = useState(false);
-
   return (
     <>
       {/* h~ 태그 고려 중 */}
       <h1 className='a11y-hidden'>구장 밖 야구</h1>
       <h2 className='a11y-hidden'>{'애월읍 위니브 감귤농장'} 포스트 페이지</h2>
 
-      <TopBasicNav setIsModalOpen={setIsModalOpen} />
+      <TopBasicNav />
       <StyledSection>
         <Post></Post>
       </StyledSection>
@@ -46,10 +42,6 @@ export default function Upload() {
         </article>
       </CommentListSection>
       <Comment txt='게시' placeholder='댓글 입력하기'></Comment>
-
-      {isModalOpen && (
-        <MoreModal isModalOpen={isModalOpen} setIsModalOpen={setIsModalOpen} />
-      )}
     </>
   );
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가

### 반영 브랜치
more-modal -> main

### 변경 사항
모달 기능
- TopBasicBar의 more버튼 클릭 시, 모달이 열리는 기능
- Tab 누를 시, 모달 외 영역에 포커스되지 않는 기능
- 모달 외 영역 클릭 시, 모달 닫힘 기능

(*추가)
- 모달 메뉴 이벤트리스너 추가

: 모달 스타일은 재활용하고, 모달 종류별로 컴포넌트화해서,
모달 메뉴 리스트, 이벤트 리스트를 props로 전달받지 않는 방향으로 리팩토링하고 싶었으나,
요소의 가장 깊은 Depth까지 같은 기능이 필요하기 때문에 props는 그대로 두었습니다.

: 같은 모달 메뉴를 공유하는 페이지가 있기 때문에, 모달 종류별로 컴포넌트하는 방향으로
우선 SettingModal 컴포넌트를 만들어 봤습니다.
피드백 부탁드립니다 :)

![image](https://github.com/FRONTENDSCHOOL5/final-08-Off-field-baseball/assets/108985221/bf1e630a-5656-44ef-b3a4-e2c54a85f4f8)