### PR TITLE
Style: 채팅 이미지 비율 수정 및 메시지  시간 표기

### DIFF
--- a/src/pages/ChatPage/ChatRoom/ChatRoom.jsx
+++ b/src/pages/ChatPage/ChatRoom/ChatRoom.jsx
@@ -12,14 +12,9 @@ const ChatRoom = () => {
       <TopChatNav />
       <ChatRoomStyle>
         <MessageWrapper>
-          <UserChat>
-            옷을 인생을 그러므로 없으면 것은 이상은 것은 우리의 위하여, 뿐이다.
-            이상의 청춘의 뼈 따뜻한 그들의 그와 약동하다. 대고, 못할 넣는
-            풍부하게 뛰노는 인생의 힘있다.
-          </UserChat>
-          <UserChat>안녕하세요 야구 글러브 아직 파시나요</UserChat>
-          <MyChat>안녕하세영</MyChat>
-          <MyChat isImg img={ChatImg2}></MyChat>
+          <UserChat time='09:50'>안녕하세요 글러브 아직 파시나요</UserChat>
+          <MyChat time='10:30'>안녕하세요</MyChat>
+          <MyChat time='10:32' isImg img={ChatImg2}></MyChat>
         </MessageWrapper>
       </ChatRoomStyle>
       <Comment />

--- a/src/pages/ChatPage/ChatRoom/MyChat.jsx
+++ b/src/pages/ChatPage/ChatRoom/MyChat.jsx
@@ -5,6 +5,7 @@ import { SYMBOL_LOGO_GRAY } from '../../../styles/CommonImages';
 const MyChat = (props) => {
   return (
     <Wrapper>
+      <MessageTime>{props.time}</MessageTime>
       <MessageContent>
         {!props.isImg ? (
           <MessageText>{props.children}</MessageText>
@@ -20,6 +21,9 @@ export default MyChat;
 
 const Wrapper = styled.div`
   margin-left: auto;
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
 `;
 
 const MessageContent = styled.div`
@@ -39,11 +43,16 @@ const MessageText = styled.p`
 
 const MessageImg = styled.img`
   width: 240px;
-  height: 240px;
+  aspect-ratio: 1 / 1.5;
+  object-fit: cover;
   background-size: cover;
   background-color: var(--primary-color);
-  background-position: center;
   border-radius: 1rem;
   border: none;
   padding: 0;
+`;
+
+const MessageTime = styled.p`
+  color: var(--gray-400);
+  margin-bottom: 2px;
 `;

--- a/src/pages/ChatPage/ChatRoom/UserChat.jsx
+++ b/src/pages/ChatPage/ChatRoom/UserChat.jsx
@@ -16,6 +16,7 @@ const UserChat = (props) => {
         ) : (
           <MessageImg src={props.img} />
         )}
+        <MessageTime>{props.time}</MessageTime>
       </MessageContent>
     </Wrapper>
   );
@@ -36,10 +37,13 @@ const Wrapper = styled.div`
 
 const MessageContent = styled.p`
   display: inline-block;
-  max-width: 240px;
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
 `;
 
 const MessageText = styled.p`
+  max-width: 240px;
   background-color: white;
   border: 1px solid var(--gray-300);
   color: #000;
@@ -52,11 +56,16 @@ const MessageText = styled.p`
 
 const MessageImg = styled.img`
   width: 240px;
-  height: 240px;
+  aspect-ratio: 1 / 1.5;
+  object-fit: cover;
   background-size: cover;
   background-color: var(--primary-color);
-  background-position: center;
   border-radius: 1rem;
   border: none;
   padding: 0;
+`;
+
+const MessageTime = styled.p`
+  color: var(--gray-400);
+  margin-bottom: 2px;
 `;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 스타일

### 반영 브랜치
style-chat -> main

### 변경 사항
- 채팅창에서 이미지 비율을 수정했습니다. 
- 메세지에 보낸 시간이 표기되게 했습니다.

### 실행 결과 스크린샷 (없을 경우 생략)
<img width="401" alt="image" src="https://github.com/FRONTENDSCHOOL5/final-08-Off-field-baseball/assets/58187854/0a21d074-0ec9-449d-a7d7-24d37037c46c">

