### PR TITLE
Feat: 게시글 앨범 목록 썸네일 클릭시 해당 게시글로 이동 기능 추가

### DIFF
--- a/src/pages/Profile/UserPost/UserPost.jsx
+++ b/src/pages/Profile/UserPost/UserPost.jsx
@@ -105,7 +105,7 @@ export default function UserPost() {
                 return post.image ? (
                   post.image.includes(',') ? (
                     <PostAlbumItem key={index}>
-                      <Link to='#'>
+                      <Link to={'/post/' + post.id}>
                         <img
                           className='thumbnail'
                           src={post.image.split(',')[0]}
@@ -116,7 +116,7 @@ export default function UserPost() {
                     </PostAlbumItem>
                   ) : (
                     <PostAlbumItem key={index}>
-                      <Link to='#'>
+                      <Link to={'/post/' + post.id}>
                         <img className='thumbnail' src={post.image} alt='' />
                       </Link>
                     </PostAlbumItem>


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가


### 반영 브랜치
feat-post -> main

### 변경 사항
프로필 페이지의 게시글 목록에서 앨범형 목록을 클릭 후 썸네일을 클릭하면 해당 게시글의 디테일 페이지로 이동하는 기능을 추가하였습니다.


