### PR TITLE
Feat: 검색 기능 추가

### DIFF
--- a/src/components/common/TopNavBar/TopSearchNav.jsx
+++ b/src/components/common/TopNavBar/TopSearchNav.jsx
@@ -4,15 +4,24 @@ import { TopNavBar, LeftArrow } from './Styled';
 import { ARROW_LEFT } from '../../../styles/CommonIcons';
 import { useNavigate } from 'react-router-dom';
 
-export default function TopSearchNav() {
+export default function TopSearchNav({ onTyping }) {
   const navigate = useNavigate();
+
   return (
     <>
       <TopNavBar>
         <button onClick={() => navigate(-1)}>
           <LeftArrow src={ARROW_LEFT} alt='뒤로 가기 버튼' />
         </button>
-        <TopSearchInput placeholder='계정 검색' />
+        <TopSearchInput
+          placeholder='계정 검색'
+          onChange={(e) => {
+            onTyping(e.target.value);
+          }}
+          // onKeyDown={(e) => {
+          //   if (e.key === 'Enter') onTyping(e.target.value);
+          // }}
+        />
       </TopNavBar>
     </>
   );

--- a/src/components/common/UserList/UserList.jsx
+++ b/src/components/common/UserList/UserList.jsx
@@ -15,17 +15,9 @@ import {
 } from '../../../styles/CommonImages';
 import FollowBtn from '../FollowBtn';
 
-export default function UserList({ profileData, teamname }) {
-  const [data, setData] = useState('');
-  const [team, setTeam] = useState('');
+export default function UserList({ user, team }) {
+  const [myTeamImg, setMyTeamImg] = useState('');
 
-  useEffect(() => {
-    if (profileData) {
-      return setData(profileData);
-    }
-  }, [profileData]);
-
-  // 받아온 마이 팀 데이터와 일치하는 이미지를 로드하도록 하는 배열
   const myTeam = [
     { id: '1', name: '두산 베어스', name2: 'doosan', img: BEARS },
     { id: '2', name: '키움 히어로즈', name2: 'kiwoom', img: HEROES },
@@ -35,35 +27,51 @@ export default function UserList({ profileData, teamname }) {
     { id: '6', name: '삼성 라이온즈', name2: 'samsung', img: LIONS },
     { id: '7', name: 'SSG 랜더스', name2: 'ssg', img: LANDERS },
     { id: '8', name: '롯데 자이언츠', name2: 'lotte', img: GIANTS },
-    { id: '9', name: '한화 이글스', name2: 'hanhwa', img: EAGLES },
+    { id: '9', name: '한화 이글스', name2: 'hanwha', img: EAGLES },
     { id: '10', name: 'KT 위즈', name2: 'kt', img: WIZ },
   ];
 
   useEffect(() => {
-    myTeam.forEach((item) => {
-      if (item.name === teamname || item.name2 === teamname) {
-        setTeam(item.img);
-      }
-    });
-  });
+    function findMyTeam() {
+      myTeam.forEach((item) => {
+        if (
+          item.name === user.intro?.split('$')[0] ||
+          item.name === user.intro?.split('$')[1]
+        ) {
+          setMyTeamImg(item.img);
+        } else if (
+          item.name2 === user.intro?.split('$')[1] ||
+          item.name === user.intro?.split('$')[1]
+        ) {
+          setMyTeamImg(item.img);
+        } else {
+        }
+      });
+    }
+    findMyTeam();
+  }, []);
+
   return (
     <>
       <UserListItem>
-        <Link to={'/profile/' + data.accountname}>
-          <img src={data.image} alt='' />
+        <Link to={'/profile/' + user.accountname}>
+          <img src={user.image} alt='' />
           <div className='user-info'>
-            <h2>{data.username}</h2>
-            <p>{data.accountname}</p>
+            <h2>{user.username}</h2>
+            <p>@{user.accountname}</p>
           </div>
         </Link>
         <Container>
-          <TeamLogo>
-            <img src={team} alt='내가 좋아하는 팀 로고' />
-          </TeamLogo>
+          {myTeamImg ? (
+            <TeamLogo>
+              <img src={myTeamImg} alt='내가 좋아하는 팀 로고' />
+            </TeamLogo>
+          ) : null}
+
           <FollowBtn
-            profileData={data}
-            targetuser={data.accountname}
-            isfollow={data.isfollow}
+            profileData={user}
+            targetuser={user.accountname}
+            isfollow={user.isfollow}
             xsBtn
           />
         </Container>

--- a/src/pages/Search/Search.jsx
+++ b/src/pages/Search/Search.jsx
@@ -1,18 +1,44 @@
-import React from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import TopSearchNav from '../../components/common/TopNavBar/TopSearchNav';
 import UserList from '../../components/common/UserList/UserList';
 import TabNav from '../../components/common/TabNavBar/TabNav';
 import styled from 'styled-components';
+import { UserContext } from '../../context/UserContext';
 
 export default function Search() {
+  const [searchUsers, setSearchUsers] = useState([]);
+
+  const { token } = useContext(UserContext);
+
+  async function fetchData(searchKeyword) {
+    try {
+      const response = await fetch(
+        `https://api.mandarin.weniv.co.kr/user/searchuser/?keyword=${searchKeyword}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+      return response.json();
+    } catch {}
+  }
+  const onTyping = (searchKeyword) => {
+    async function handleFetchData() {
+      const users = await fetchData(searchKeyword);
+      console.log(users);
+      setSearchUsers(users.slice(0, 20));
+    }
+    handleFetchData();
+  };
+
   return (
     <>
-      <TopSearchNav />
+      <TopSearchNav onTyping={onTyping} />
       <SearchList>
-        {/* 임시 props */}
-        <UserList loc='follow' id='samsung' nickname='오재일' isFollow={true} />
-        <UserList loc='follow' id='hanwha' nickname='문동주' isFollow={false} />
-        <UserList loc='follow' id='lotte' nickname='김원중' isFollow={true} />
+        {searchUsers.map((user) => {
+          return <UserList key={user._id} user={user} />;
+        })}
       </SearchList>
       <TabNav />
     </>


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가

### 반영 브랜치
feat-search -> main

### 변경 사항
- 검색 기능을 추가했습니다.
  - 글자 타이핑과 동시에 검색이 되며, 20개씩 리스트를 불러옵니다.
  - myteam 설정이 되어 있는 경우 응원중인 팀의 로고가 팔로우 버튼 좌측에 뜨고, 팀이 없으면 이미지가 뜨지 않습니다. 

### 실행 결과 스크린샷 (없을 경우 생략)
![검색화면](https://github.com/FRONTENDSCHOOL5/final-08-Off-field-baseball/assets/58187854/606f997f-ce81-44b4-9032-23caff8f1496)