### PR TITLE
Style: ProfileHeader 스타일 약간 수정

### DIFF
--- a/src/pages/Profile/ProfileHeader/ProfileHeader.jsx
+++ b/src/pages/Profile/ProfileHeader/ProfileHeader.jsx
@@ -108,7 +108,7 @@ const UserHeader = styled.div`
     border-radius: 50%;
     object-fit: cover;
   }
-  margin-bottom: 8px;
+  margin-bottom: 12px;
 `;
 
 const Follow = styled(Link)`
@@ -137,29 +137,31 @@ const MyTeamShow = styled.div`
   border-radius: 10px;
   padding: 4px;
   width: 150px;
+  height: 26px;
   margin: 0 auto;
   justify-content: center;
   gap: 4px;
   cursor: default;
   img {
     width: 20px;
+    height: auto;
   }
 
   span {
     color: var(--gray-400);
   }
 
-  margin-bottom: 9px;
+  margin-bottom: 12px;
 `;
 
 const UserInfo = styled.div`
   margin: 0 auto;
   text-align: center;
-  margin-bottom: 24px;
+  margin-bottom: 16px;
   h2 {
     font-size: 1.6rem;
     font-weight: bold;
-    margin-bottom: 6px;
+    margin-bottom: 10px;
   }
   p {
     color: var(--gray-400);
@@ -167,7 +169,7 @@ const UserInfo = styled.div`
 
   p.id {
     font-size: 1.2rem;
-    margin-bottom: 16px;
+    margin-bottom: 15px;
   }
 
   p.text {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 스타일

### 반영 브랜치
style-profile -> main

### 변경 사항
ProfileHeader의 간격을 약간 수정하였습니다.
마이팀 태그의 height 값을 26px로 고정하였습니다.

### 실행 결과 스크린샷 (없을 경우 생략)
<img width="437" alt="image" src="https://github.com/FRONTENDSCHOOL5/final-08-Off-field-baseball/assets/58187854/6d6eca4a-3398-448c-9cb5-6c176326b2c6">
