### PR TITLE
Feat: 회원정보수정  / 이미지 업데이트 정상 적용

### DIFF
--- a/src/pages/Profile/ProfileEdit.jsx
+++ b/src/pages/Profile/ProfileEdit.jsx
@@ -51,10 +51,38 @@ export default function EditProfile() {
     }
   }, [isVaildIntro, isVaildUsername, isVaildAccountname]);
 
+  // API
   const url = 'https://api.mandarin.weniv.co.kr';
+  const uploadProfileImage = async () => {
+    try {
+      if (image !== '') {
+        const formData = new FormData();
+        formData.append('image', image);
+
+        const reqPath = '/image/uploadfile';
+        const reqUrl = url + reqPath;
+
+        const res = await fetch(reqUrl, {
+          method: 'POST',
+          body: formData,
+        });
+
+        const json = await res.json();
+        return 'https://api.mandarin.weniv.co.kr/' + json.filename;
+      } else {
+        // 기본 프로필 이미지
+        return src;
+      }
+    } catch (err) {
+      console.log(err);
+      // 이미지 업로드 실패 시 빈문자열
+      return '';
+    }
+  };
 
   const handleEdit = async () => {
     try {
+      const profileImageUrl = await uploadProfileImage();
       const url = 'https://api.mandarin.weniv.co.kr';
       const reqPath = '/user';
 
@@ -65,7 +93,7 @@ export default function EditProfile() {
           username: username,
           accountname: accountnameValue,
           intro: intro + '$' + selectedOpt,
-          image: '',
+          image: profileImageUrl,
         },
       };
 
@@ -90,23 +118,6 @@ export default function EditProfile() {
       if (selectedOpt && selectedOpt !== '없음') {
         userData.user.intro += `$${teamName[selectedOpt]}`;
       }
-      if (src !== BASIC_PROFILE_LG) {
-        const formData = new FormData();
-        formData.append('image', image);
-        const reqPath = '/image/uploadfile';
-        const reqUrl = url + reqPath;
-        const res = await fetch(reqUrl, {
-          method: 'POST',
-          body: formData,
-        });
-        const json = await res.json();
-        userData.user.image =
-          'https://api.mandarin.weniv.co.kr/' + json.filename;
-      } else {
-        // 서버에 저장된 기본 프로필 저장
-        userData.user.image =
-          'https://api.mandarin.weniv.co.kr/1687309142552.png';
-      }
     } catch (err) {
       console.log(err);
     }
@@ -114,6 +125,7 @@ export default function EditProfile() {
 
   const handleForm = (e) => {
     e.preventDefault();
+    console.log(src);
     handleEdit();
   };
 
@@ -202,6 +214,10 @@ export default function EditProfile() {
       setUsername(res.user.username);
       setAccountnameValue(res.user.accountname);
       setCurrentAccountname(res.user.accountname); //임시
+      // 이미지
+      if (res.user.image !== BASIC_PROFILE_LG) {
+        setSrc(res.user.image);
+      }
     } catch (err) {
       console.log(err);
     }
@@ -312,6 +328,11 @@ const StyledJoinProfile = styled.section`
   }
   #profileImg {
     border: none;
+  }
+
+  .img-label {
+    width: 110px;
+    margin: 0 auto;
   }
   .img-label img {
     width: 110px;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 스타일


### 반영 브랜치
feat-profile -> main

### 변경 사항
* 프로필 수정 페이지 접속 시 기존 프로필 이미지를 불러옵니다.
* 새롭게 업로드하는 이미지로 미리 보기를 변경합니다.
* 클릭 시 이미지 업로드 창이 뜨는 input  => 기존에 흰 화면이 포함된 넓은 영역에서 프로필 이미지 영역으로 축소하였습니다.
* 수정 페이지에 접속했으나 이미지를 수정하지 않은 경우에도 저장 버튼을 누르면 기본 empty 이미지로 리셋 되는 문제를 해결하였습니다.


👍 VS Code Live Share
Co-authored-by: Kim Hayeon <KimHayeon1@users.noreply.github.com>


### 테스트 결과 (없을 경우 생략)
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

### 실행 결과 스크린샷 (없을 경우 생략)
