### PR TITLE
Feat: 상품등록 페이지 / input 제한 및 focus 테마 변경 기능 추가

### DIFF
--- a/src/pages/Product/ProductUpload.jsx
+++ b/src/pages/Product/ProductUpload.jsx
@@ -3,6 +3,7 @@ import TopUploadNav from '../../components/common/TopNavBar/TopUploadNav';
 import styled from 'styled-components';
 import { IMG_BUTTON, X } from '../../styles/CommonIcons';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import Form from '../../components/common/Form/Form';
 
 export default function ProductUpload() {
   const [price, setPrice] = useState('');
@@ -16,7 +17,7 @@ export default function ProductUpload() {
 
   // 모든 입력칸에 값이 입력되면 저장 버튼 활성화
   useEffect(() => {
-    if (productName && price && link && imgPre) {
+    if (productName.replace(/ /g, '').length > 1 && price && link && imgPre) {
       setIsValid(true);
     } else {
       setIsValid(false);
@@ -71,10 +72,10 @@ export default function ProductUpload() {
   };
 
   // 상품소개란 텍스트 길이만큼 textarea height 확대
-  const ResizeHeight = (e) => {
-    e.target.style.height = 'auto';
-    e.target.style.height = e.target.scrollHeight + 'px';
-  };
+  // const ResizeHeight = (e) => {
+  //   e.target.style.height = 'auto';
+  //   e.target.style.height = e.target.scrollHeight + 'px';
+  // };
 
   // 이미지 삭제
   const handleImgDelete = () => {
@@ -219,26 +220,26 @@ export default function ProductUpload() {
             onChange={handleImgChange}
           />
         </EmptyImg>
-
-        <ProductInput>
+        <Form>
+          {/* <ProductInput> */}
           <label htmlFor='name'>상품명</label>
           <input
             type='text'
             id='name'
-            minLength='2'
             maxLength='25'
             placeholder='2~25자 이내여야 합니다.'
-            required
             value={productName && productName}
-            onChange={(e) => setProductName(e.target.value)}
+            onChange={(e) =>
+              setProductName(e.target.value.replace(/\s\s+/g, ' '))
+            }
           />
 
           <label htmlFor='price'>가격</label>
           <input
             type='text'
             id='price'
+            maxLength='11'
             placeholder='숫자만 입력이 가능합니다.'
-            required
             value={price && price}
             onChange={addComma}
           />
@@ -247,14 +248,14 @@ export default function ProductUpload() {
           <textarea
             id='info'
             placeholder='판매하는 상품 정보를 입력해주세요.'
-            required
             value={link && link}
             onChange={(e) => {
-              ResizeHeight(e);
+              // ResizeHeight(e);
               setLink(e.target.value);
             }}
           />
-        </ProductInput>
+          {/* </ProductInput> */}
+        </Form>
       </ProductInfo>
     </>
   );
@@ -339,6 +340,14 @@ const ProductInput = styled.div`
   input:focus {
     outline: none;
     border-bottom: 1px solid var(--primary-color);
+  }
+
+  input:focus:not(.invalid),
+  textarea:focus:not(.invalid) {
+    border-color: ${(props) =>
+      props.myTeam === 'kt'
+        ? 'var(--tertiary-color-kt)'
+        : 'var(--primary-color-' + (props.myTeam || 'default') + ')'};
   }
 
   textarea:focus {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 스타일


### 반영 브랜치
style-upload -> main 

### 변경 사항
* 가격 100,000,000까지 기재 가능하게 입력 제한 추가
* 상품명 2글자(공백 제외)부터 저장버튼 활성화되게 수정 
* 상품명에 연속된 공백 입력할 수 없도록 제한

* Form 컴포넌트 이용해서 팀 테마에 맞는 focus 스타일 구현
👍 Co-authored-by: Kim Hayeon <KimHayeon1@users.noreply.github.com>

* textarea => 프로필 생성, 프로필 수정, 상품 등록, 상품 수정 페이지에 통일성을 위해 하연님께서 수정 고려 중




### 실행 결과 스크린샷 (없을 경우 생략)
