### PR TITLE
Feat: 회원정보수정 페이지 / 소개란 input에서 textarea로 변경

### DIFF
--- a/src/pages/Profile/ProfileEdit.jsx
+++ b/src/pages/Profile/ProfileEdit.jsx
@@ -1,4 +1,4 @@
-import { BASIC_PROFILE_LG, X } from '../../styles/CommonIcons';
+import { X } from '../../styles/CommonIcons';
 import styled from 'styled-components';
 import TeamSelect from '../../components/common/Select/TeamSelect';
 import Form from '../../components/common/Form/Form';
@@ -298,7 +298,7 @@ export default function EditProfile() {
         event={handleForm}
         selectedTeam={selectedTeam}
       />
-      <StyledJoinProfile myTeam={selectedTeam}>
+      <StyledEditProfile myTeam={selectedTeam}>
         <Form selectedTeam={selectedTeam}>
           <label htmlFor='profileImg'>
             <div className='img-wrap'>
@@ -357,7 +357,7 @@ export default function EditProfile() {
           />
           {messageAccountname && <strong>{messageAccountname}</strong>}
           <label htmlFor='intro'>소개</label>
-          <input
+          <textarea
             id='intro'
             type='text'
             placeholder='자신에 대해 소개해 주세요!'
@@ -368,6 +368,7 @@ export default function EditProfile() {
             }}
             pattern='[^$]+'
             className={messageIntro && 'invalid'}
+            maxLength={150}
           />
           {messageIntro && <strong>{messageIntro}</strong>}
           <TeamSelect
@@ -376,12 +377,12 @@ export default function EditProfile() {
             setSelectedOpt={setSelectedOpt}
           ></TeamSelect>
         </Form>
-      </StyledJoinProfile>
+      </StyledEditProfile>
     </>
   );
 }
 
-const StyledJoinProfile = styled.section`
+const StyledEditProfile = styled.section`
   padding: 78px 34px;
 
   #profileImg {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 스타일


### 반영 브랜치
feat-profile -> main

### 변경 사항
기존 input이었던 소개란을 textarea로 변경해 프로필 생성 페이지와 통일하였습니다.

### 실행 결과 스크린샷 (없을 경우 생략)
![image](https://github.com/FRONTENDSCHOOL5/final-08-Off-field-baseball/assets/126536476/e5127e64-ddd0-4977-a68d-cb2bb2e7651b)
