### PR TITLE
fix: 게시글이 레이아웃 범위를 벗어나는 에러 수정

### DIFF
--- a/src/components/common/Post/Post.jsx
+++ b/src/components/common/Post/Post.jsx
@@ -257,6 +257,7 @@ const UserText = styled.pre`
   line-height: 1.3;
   position: relative;
   word-break: break-all;
+  white-space: pre-wrap;
 `;
 
 const SwiperWrapper = styled(Swiper)`


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 버그 수정


### 반영 브랜치
fix-refactor -> main

### 변경 사항
게시글이 레이아웃 범위를 벗어나는 에러를 수정하였습니다


### 실행 결과 스크린샷 (없을 경우 생략)
수정 전
![image](https://github.com/FRONTENDSCHOOL5/final-08-Off-field-baseball/assets/116331221/a0322ecb-436a-435e-9840-6d4fedb46785)


수정 후
![image](https://github.com/FRONTENDSCHOOL5/final-08-Off-field-baseball/assets/116331221/ffc112ae-dd5f-40d5-8599-8e26f758d90a)
