### PR TITLE
fix: 무한스크롤 렌더링 아이템 수 오작동 및 이전 검색어 결과가 렌더링되는 오류 수정

### DIFF
--- a/src/components/common/TopNavBar/TopSearchNav.jsx
+++ b/src/components/common/TopNavBar/TopSearchNav.jsx
@@ -4,7 +4,7 @@ import { TopNavBar, LeftArrow } from './Styled';
 import { ARROW_LEFT } from '../../../styles/CommonIcons';
 import { useNavigate } from 'react-router-dom';
 
-const TopSearchNav = ({ keyword, onChange, onTyping }) => {
+const TopSearchNav = ({ keyword, onChange, onTyping, searchInp }) => {
   const navigate = useNavigate();
 
   return (
@@ -14,6 +14,7 @@ const TopSearchNav = ({ keyword, onChange, onTyping }) => {
           <LeftArrow src={ARROW_LEFT} alt='뒤로 가기 버튼' />
         </button>
         <TopSearchInput
+          ref={searchInp}
           placeholder='계정 검색'
           value={keyword}
           onChange={(e) => {

--- a/src/pages/Search/Search.jsx
+++ b/src/pages/Search/Search.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useState, useEffect, useContext, useRef } from 'react';
 import TopSearchNav from '../../components/common/TopNavBar/TopSearchNav';
 import UserList from '../../components/common/UserList';
 import TabNav from '../../components/common/TabNav';
@@ -35,12 +35,17 @@ const Search = () => {
   const onTyping = () => {
     async function handleFetchData() {
       const users = await fetchData();
-      // console.log(users);
-      // console.log(searchKeyword);
-      setSearchUsers(users.slice(0, 20));
-      setCntUserList(cntUserList + 20);
+      // 현재 inp 값으로 바뀌기 이전의 함수라면 얼리리턴
+      if (keyword !== searchInp.current.value) {
+        return;
+      }
+      if (cntUserList === 20) {
+        setSearchUsers(users.slice(0, cntUserList));
+        setCntUserList(cntUserList + 20);
+      } else {
+        setSearchUsers(users.slice(0, cntUserList - 20));
+      }
       setUserList(users);
-      console.log(users);
     }
     handleFetchData();
   };
@@ -66,7 +71,7 @@ const Search = () => {
     window.addEventListener('scroll', addUser);
 
     return () => window.removeEventListener('scroll', addUser);
-  }, [cntUserList]);
+  }, [cntUserList, userList]);
 
   useEffect(() => {
     let timeout;
@@ -81,13 +86,16 @@ const Search = () => {
 
     return () => {
       clearTimeout(timeout);
-      setSearchUsers([]);
     };
   }, [keyword]);
-
+  const searchInp = useRef(null);
   return (
     <>
-      <TopSearchNav keyword={keyword} onChange={setKeyword} />
+      <TopSearchNav
+        keyword={keyword}
+        onChange={setKeyword}
+        searchInp={searchInp}
+      />
       <SearchList>
         {searchUsers.map((user) => {
           return <UserList key={user._id} user={user} keyword={keyword} />;


### PR DESCRIPTION
### PR 타입
- [x] 버그 수정

### 반영 브랜치
fix-searchPage -> main
### 변경 사항
fix: 무한스크롤 렌더링 아이템 수 오작동 및 이전 검색어 결과가 렌더링되는 오류 수정

### 실행 결과 스크린샷
잘 동작하는지 확인하기 위해, setTimeOut을 0초로 설정해서 테스트한 gif (PR한 코드는 200초)
1. 변경 전
![17](https://github.com/FRONTENDSCHOOL5/final-08-Off-field-baseball/assets/108985221/1697ff79-4008-4d1d-8122-7d59ead83bc7)
2. 변경 후
![18](https://github.com/FRONTENDSCHOOL5/final-08-Off-field-baseball/assets/108985221/62b6d09e-d357-4868-9806-6639c3bebbba)
3. 원인
![image](https://github.com/FRONTENDSCHOOL5/final-08-Off-field-baseball/assets/108985221/d7e70a76-4f1c-48c9-89a2-60666941681a)
입력값 변경 시, clearTimeOut로 클린업하기 전, setTimeOut이 실행되었다면, 이전 검색어에 대한 함수 실행(onTyping)이 취소되지 않았다.
따라서 현재 입력값과, data받아올 때 사용된 키워드(입력값)이 다르다면 얼리리턴.